### PR TITLE
ci: Use uvx to simplify builds

### DIFF
--- a/.github/actions/build-types/action.yaml
+++ b/.github/actions/build-types/action.yaml
@@ -23,7 +23,7 @@ runs:
     - name: Install dependencies for Base Package
       shell: bash
       run: |
-        pip install -e .
+        python -m pip install .
     - name: Install func_adl_servicex_type_generator
       uses: actions/checkout@v4
       with:
@@ -40,10 +40,10 @@ runs:
       shell: bash
       run: |
         cd func_adl_servicex_type_generator
-        pip install -e .
+        python -m pip install .
         cd ..
         cd func-adl-types-atlas
-        pip install -e .
+        python -m pip install .
     - name: Cache Type YAML Files
       id: cache-type-yaml
       uses: actions/cache/restore@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,6 +63,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v5
       - name: Tag ID
         id: determine-tag
         uses: ./.github/actions/determine-tag
@@ -75,15 +77,19 @@ jobs:
           func_adl_servicex_type_generator_version: $func_adl_servicex_type_generator_version
           func_adl_types_atlas_version: $func_adl_types_atlas_version
           python_package_base_version: "${{ steps.determine-tag.outputs.package_version }}"
-      - name: Publish to PyPi with Hatch
+      - name: Build distributions
         shell: bash
         run: |
-          pip install hatch
           cd ./cache/package/${{ matrix.release_version }}
-          hatch build
-          pwd
-          ls
+          uvx --from build pyproject-build .
+          ls -lhtra dist
+      - name: Verify distributions
+        shell: bash
+        run: |
+          cd ./cache/package/${{ matrix.release_version }}
+          uvx twine check --strict dist/*
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: ./cache/package/${{ matrix.release_version }}/dist
+          print-hash: true


### PR DESCRIPTION
* uvx allows for running commands that will be executed in their own temporary virtual environments that are managed and handled with uv.
* Verify distributions with twine prior to upload.
* Use regular pip installs over editable installs as nothing should be locally relevant.

Requires PR #3 to go in first.